### PR TITLE
Updated the list of games on the Battle.net launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,15 +35,22 @@ table for the current known support for the launcher.
 ## Games
 Game | Code | Launcher Support
 ---- | ---- | ----------------
-Diablo 3 | D3 | Game launches, Status updated, Overlay works
-Destiny 2 | DST2 | Untested
+Diablo II: Resurrected | OSI | Untested
+Diablo III | D3 | Game launches, Status updated, Overlay works
+Hearthstone | WTCG | Game launches, Status updated, Overlay works
 Heroes of the Storm | HERO | Game launches, No Status, No Overlay
 Overwatch | PRO | Game launches, Status updated, Overlay works
 Starcraft | S1 | Untested
-Starcraft 2 | S2 | Untested
+Starcraft 2 | S2 | Game launches
+Warcraftt III: Reforged | W3 | Untested
 World of Warcraft | WOW | Untested
-Hearthstone | WTCG | Game launches, Status updated, Overlay works
+World of Warcraft Classic + BC | WOWC | Untested
+Call of Duty: Black Ops - Coold War | ZEUS | Untested
 Call of Duty: Black Ops 4 | VIPR | Untested
+Call of Duty: MW 2019 | ODIN | Untested
+Call of Duty: MW 2 Campaign Remastered | LAZR | Untested
+Call of Duty: Vanguard | FORE | Untested
+Crash Bandicoot 4: It's About Time | WLBY | Untested
 
 ## License and Copyrights
 The code in this repository is released under the MIT license.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Game | Code | Launcher Support
 ---- | ---- | ----------------
 Diablo II: Resurrected | OSI | Untested
 Diablo III | D3 | Game launches, Status updated, Overlay works
+Diablo IV | D4 | Untested
 Hearthstone | WTCG | Game launches, Status updated, Overlay works
 Heroes of the Storm | HERO | Game launches, No Status, No Overlay
 Overwatch | PRO | Game launches, Status updated, Overlay works

--- a/SteamBattleNetLauncher/Program.cs
+++ b/SteamBattleNetLauncher/Program.cs
@@ -9,15 +9,23 @@ using System.Text;
 namespace SteamBattleNetLauncher {
     static class Program {
         static Dictionary<string, string[]> GAME_TOKEN_MAP = new Dictionary<string, string[]>(){
-            {"D3", new string[]{"D3", "Diablo 3"}},
+            {"RTRO", new string[]{"RTRO", "Blizzard Arcade Collection"}},
+            {"OSI", new string[]{"OSI", "Diablo II: Resurrected"}},
+            {"D3", new string[]{"D3", "Diablo III"}},
+            {"WTCG", new string[]{"WTCG", "Hearthstone"}},
             {"HERO", new string[]{"Hero", "Heroes of the Storm"}},
             {"PRO", new string[]{"Pro", "Overwatch"}},
             {"S1", new string[]{"S1", "Starcraft"}},
             {"S2", new string[]{"S2", "Starcraft 2"}},
+            {"W3", new string[]{"W3", "Warcraft III: Reforged"}},
             {"WOW", new string[]{"WoW", "World of Warcraft"}},
-            {"WTCG", new string[]{"WTCG", "Hearthstone"}},
-            {"VIPR", new string[]{ "VIPR", "Call of Duty: Black Ops 4"}},
-            {"ODIN", new string[]{ "ODIN", "Call of Duty: Modern Warfare (2019)"}}
+            {"WoWC", new string[]{"WoWC", "World of Warcraft Classic + BC"}},
+            {"ZEUS", new string[]{"ZEUS", "Call of Duty: Black Ops - Cold War"}},
+            {"VIPR", new string[]{"VIPR", "Call of Duty: Black Ops 4"}},
+            {"ODIN", new string[]{"ODIN", "Call of Duty: MW 2019"}},
+            {"LAZR", new string[]{"LAZR", "Call of Duty: MW 2 Campaign Remastered"}},
+            {"FORE", new string[]{"FORE", "Call of Duty: Vanguard"}},
+            {"WLBY", new string[]{"WLBY", "Crash Bandicoot 4: It's About Time"}},
         };
 
         static int PROCESS_WAIT_LIMIT = 10000;

--- a/SteamBattleNetLauncher/Program.cs
+++ b/SteamBattleNetLauncher/Program.cs
@@ -12,6 +12,7 @@ namespace SteamBattleNetLauncher {
             {"RTRO", new string[]{"RTRO", "Blizzard Arcade Collection"}},
             {"OSI", new string[]{"OSI", "Diablo II: Resurrected"}},
             {"D3", new string[]{"D3", "Diablo III"}},
+            {"D4", new string[]{"D4", "Diablo IV"}},
             {"WTCG", new string[]{"WTCG", "Hearthstone"}},
             {"HERO", new string[]{"Hero", "Heroes of the Storm"}},
             {"PRO", new string[]{"Pro", "Overwatch"}},


### PR DESCRIPTION
I've updated the allowed list of games to be launched based on the list in this Steam page:

https://steamcommunity.com/sharedfiles/filedetails/?id=1113049716

The list can be seen around the middle of the page. Hope this helps!
I've also managed to open SC2 using your tool, so I though I could update the list of games as well.